### PR TITLE
keep the state of healthy

### DIFF
--- a/src/AspNetCore.Health/HealthCheckService.cs
+++ b/src/AspNetCore.Health/HealthCheckService.cs
@@ -36,7 +36,7 @@ namespace AspNetCore.Health
 
                     Results.Add(result);
 
-                    healthy = result.Status == HealthCheckStatus.Healthy || result.Status == HealthCheckStatus.Warning;
+                    healthy = (result.Status == HealthCheckStatus.Healthy || result.Status == HealthCheckStatus.Warning) && healthy;
 
                     state.Append($"{check.Key} : {(healthy ? "Healthy" : "Unhealthy")}");
                 }

--- a/test/AspNetCore.Health.Tests/MiddlewareTests.cs
+++ b/test/AspNetCore.Health.Tests/MiddlewareTests.cs
@@ -32,6 +32,26 @@ namespace AspNetCore.Health.Tests
         }
 
         [Fact]
+        public async Task returns_a_httpstatuscode_internalservererror_if_there_are_any_unhealthy_service_with_atleast_one_healthy()
+        {
+            var builder = new WebHostBuilder()
+                .ConfigureServices(services =>
+                    {
+                        services.AddHealthChecks(context =>
+                        {
+                            context.AddUrlCheck("http://invalidurl");
+                            context.AddUrlCheck("http://www.google.com");
+                        });
+                    })
+                .Configure(app => app.UseHealthCheck("/health"));
+            var server = new TestServer(builder);
+
+            var response = await server.CreateClient().GetAsync("/health");
+
+            response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        }
+
+        [Fact]
         public async Task returns_a_httpstatuscode_ok_if_there_are_any_unhealthy_service()
         {
             var builder = new WebHostBuilder()


### PR DESCRIPTION
Before the final value for healthy was only being determined based off of the last item to be health checked. Now it will keep the state of healthy so if one of the services is unhealthy then the whole health check will fail. 